### PR TITLE
Add minimal web app for AI-generated presentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# pptgeneration
-First project would work on(long term)
+# PPT Generation App
+
+This project provides a minimal web application for creating PowerPoint presentations using OpenAI's API.
+It includes a simple Flask back end with user authentication and a basic HTML front end.
+
+## Setup
+
+1. Create and activate a virtual environment (optional).
+2. Install dependencies:
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+3. Set environment variables:
+
+- `OPENAI_API_KEY` – your OpenAI key
+- `SECRET_KEY` – secret string for Flask sessions
+
+4. Run the server:
+
+```bash
+python backend/app.py
+```
+
+5. Open `http://localhost:5000` in your browser to register and start creating presentations.
+
+Generated presentations are saved in the `presentations/` directory.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,92 @@
+from flask import Flask, request, jsonify, send_file, session, render_template, redirect, url_for
+from flask_sqlalchemy import SQLAlchemy
+from werkzeug.security import generate_password_hash, check_password_hash
+import os
+from ppt_generator import create_presentation
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', 'change-me')
+
+db = SQLAlchemy(app)
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+
+    presentations = db.relationship('Presentation', backref='owner', lazy=True)
+
+class Presentation(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    file_path = db.Column(db.String(200), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+
+@app.before_first_request
+def create_tables():
+    db.create_all()
+
+# ------------------------ Auth Routes -------------------------
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        if User.query.filter_by(username=username).first():
+            return 'User already exists', 400
+        user = User(username=username, password_hash=generate_password_hash(password))
+        db.session.add(user)
+        db.session.commit()
+        return redirect(url_for('login'))
+    return render_template('register.html')
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if not user or not check_password_hash(user.password_hash, password):
+            return 'Invalid credentials', 401
+        session['user_id'] = user.id
+        return redirect(url_for('index'))
+    return render_template('login.html')
+
+@app.route('/logout')
+def logout():
+    session.pop('user_id', None)
+    return redirect(url_for('login'))
+
+# ---------------------- Presentation Routes -------------------
+@app.route('/')
+def index():
+    if 'user_id' not in session:
+        return redirect(url_for('login'))
+    user = User.query.get(session['user_id'])
+    return render_template('index.html', presentations=user.presentations)
+
+@app.route('/presentations', methods=['POST'])
+def create():
+    if 'user_id' not in session:
+        return redirect(url_for('login'))
+    title = request.form['title']
+    num_slides = int(request.form.get('num_slides', 5))
+    file_path = create_presentation(title, num_slides)
+    pres = Presentation(title=title, file_path=file_path, user_id=session['user_id'])
+    db.session.add(pres)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+@app.route('/presentations/<int:pres_id>')
+def download(pres_id):
+    if 'user_id' not in session:
+        return redirect(url_for('login'))
+    pres = Presentation.query.get_or_404(pres_id)
+    if pres.user_id != session['user_id']:
+        return 'Forbidden', 403
+    return send_file(pres.file_path, as_attachment=True)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/backend/ppt_generator.py
+++ b/backend/ppt_generator.py
@@ -1,0 +1,61 @@
+import os
+import openai
+from pptx import Presentation
+from pptx.util import Inches
+
+openai.api_key = os.getenv('OPENAI_API_KEY')
+
+
+def generate_outline(title, num_slides):
+    prompt = (
+        f"Create an outline with {num_slides} slide titles for a PowerPoint presentation titled '{title}'."
+    )
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}]
+    )
+    raw_lines = response.choices[0].message.content.split('\n')
+    slide_titles = [line.strip().split('. ', 1)[-1] for line in raw_lines if line.strip()]
+    return slide_titles
+
+
+def generate_slide_content(slide_title):
+    prompt = (
+        f"Generate 3 to 5 bullet points for a PowerPoint slide titled '{slide_title}'."
+        " Keep it concise and clear."
+    )
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}]
+    )
+    raw_lines = response.choices[0].message.content.split('\n')
+    bullet_points = [line.strip('-• ').strip() for line in raw_lines if line.strip()]
+    return bullet_points
+
+
+def create_presentation(title, num_slides):
+    prs = Presentation()
+    title_slide_layout = prs.slide_layouts[0]
+    content_slide_layout = prs.slide_layouts[1]
+
+    slide = prs.slides.add_slide(title_slide_layout)
+    slide.shapes.title.text = title
+    slide.placeholders[1].text = "Generated using OpenAI"
+
+    slide_titles = generate_outline(title, num_slides)
+    for slide_title in slide_titles:
+        bullet_points = generate_slide_content(slide_title)
+        slide = prs.slides.add_slide(content_slide_layout)
+        slide.shapes.title.text = slide_title
+        body_shape = slide.placeholders[1]
+        tf = body_shape.text_frame
+        tf.clear()
+        for point in bullet_points:
+            p = tf.add_paragraph()
+            p.text = point
+            p.level = 0
+
+    output_path = os.path.join('presentations', f"{title.replace(' ', '_')}.pptx")
+    os.makedirs('presentations', exist_ok=True)
+    prs.save(output_path)
+    return output_path

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+flask
+flask_sqlalchemy
+python-dotenv
+python-pptx
+openai
+Werkzeug

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+  <title>My Presentations</title>
+</head>
+<body>
+  <h1>Your Presentations</h1>
+  <form method="post" action="/presentations">
+    <label>Title: <input type="text" name="title" required></label>
+    <label>Number of slides: <input type="number" name="num_slides" value="5"></label>
+    <button type="submit">Create</button>
+  </form>
+  <ul>
+    {% for p in presentations %}
+      <li><a href="/presentations/{{ p.id }}">{{ p.title }}</a></li>
+    {% endfor %}
+  </ul>
+  <a href="/logout">Logout</a>
+</body>
+</html>

--- a/frontend/templates/login.html
+++ b/frontend/templates/login.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+  <title>Login</title>
+</head>
+<body>
+  <h1>Login</h1>
+  <form method="post">
+    <label>Username: <input type="text" name="username" required></label><br>
+    <label>Password: <input type="password" name="password" required></label><br>
+    <button type="submit">Login</button>
+  </form>
+  <p>Don't have an account? <a href="/register">Register</a></p>
+</body>
+</html>

--- a/frontend/templates/register.html
+++ b/frontend/templates/register.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+  <title>Register</title>
+</head>
+<body>
+  <h1>Register</h1>
+  <form method="post">
+    <label>Username: <input type="text" name="username" required></label><br>
+    <label>Password: <input type="password" name="password" required></label><br>
+    <button type="submit">Register</button>
+  </form>
+  <p>Already have an account? <a href="/login">Login</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create Flask backend with user auth and PPT generation
- add OpenAI-powered presentation helper
- include simple HTML templates for login, register and listing presentations
- document setup steps in README

## Testing
- `python3 -m py_compile backend/app.py backend/ppt_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_6856f12f4ff0833392d3b8c702805bdc